### PR TITLE
Endgame rumble

### DIFF
--- a/Robot/src/main/java/com/swrobotics/lib/input/XboxController.java
+++ b/Robot/src/main/java/com/swrobotics/lib/input/XboxController.java
@@ -3,6 +3,7 @@ package com.swrobotics.lib.input;
 import com.swrobotics.lib.utils.MathUtil;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.wpilibj.GenericHID;
+import edu.wpi.first.wpilibj.GenericHID.RumbleType;
 
 import java.util.Arrays;
 import java.util.List;
@@ -81,6 +82,10 @@ public final class XboxController extends InputSource {
     public void setRumble(double amount) {
         xbox.setRumble(GenericHID.RumbleType.kLeftRumble, amount);
         xbox.setRumble(GenericHID.RumbleType.kRightRumble, amount);
+    }
+
+    public void setRumble(RumbleType type, double amount) {
+        xbox.setRumble(type, amount);
     }
 
     public Translation2d getLeftStick() {

--- a/Robot/src/main/java/com/swrobotics/robot/commands/RumblePatternCommands.java
+++ b/Robot/src/main/java/com/swrobotics/robot/commands/RumblePatternCommands.java
@@ -14,8 +14,6 @@ public class RumblePatternCommands {
 
     public static Command endgameAlert(XboxController controller, double power) {
         // 1 and 3 4
-
-
         return Commands.sequence(
             rumbleForTimeCommand(controller, RumbleType.kBothRumble, power, eightNoteSeconds * 2),
             new WaitCommand(eightNoteSeconds),

--- a/Robot/src/main/java/com/swrobotics/robot/commands/RumblePatternCommands.java
+++ b/Robot/src/main/java/com/swrobotics/robot/commands/RumblePatternCommands.java
@@ -1,0 +1,32 @@
+package com.swrobotics.robot.commands;
+
+import com.swrobotics.lib.input.XboxController;
+
+import edu.wpi.first.wpilibj.GenericHID.RumbleType;
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.Commands;
+import edu.wpi.first.wpilibj2.command.RunCommand;
+import edu.wpi.first.wpilibj2.command.WaitCommand;
+
+public class RumblePatternCommands {
+    private static final int BPM = 140;
+    private static final double eightNoteSeconds = 60.0 / BPM / 2.0; // Assume 4:4
+
+    public static Command endgameAlert(XboxController controller, double power) {
+        // 1 and 3 4
+
+
+        return Commands.sequence(
+            rumbleForTimeCommand(controller, RumbleType.kBothRumble, power, eightNoteSeconds * 2),
+            new WaitCommand(eightNoteSeconds),
+            rumbleForTimeCommand(controller, RumbleType.kLeftRumble, power, eightNoteSeconds),
+            rumbleForTimeCommand(controller, RumbleType.kRightRumble, power, eightNoteSeconds),
+            new WaitCommand(eightNoteSeconds),
+            rumbleForTimeCommand(controller, RumbleType.kBothRumble, power, eightNoteSeconds * 2)
+        );
+    }
+
+    public static Command rumbleForTimeCommand(XboxController controller, RumbleType type, double amount, double timeSeconds) {
+        return new RunCommand(() -> controller.setRumble(type, amount)).withTimeout(timeSeconds).finallyDo(() -> controller.setRumble(0));
+    }
+}

--- a/Robot/src/main/java/com/swrobotics/robot/commands/RumblePatternCommands.java
+++ b/Robot/src/main/java/com/swrobotics/robot/commands/RumblePatternCommands.java
@@ -14,6 +14,8 @@ public class RumblePatternCommands {
 
     public static Command endgameAlert(XboxController controller, double power) {
         // 1 and 3 4
+
+
         return Commands.sequence(
             rumbleForTimeCommand(controller, RumbleType.kBothRumble, power, eightNoteSeconds * 2),
             new WaitCommand(eightNoteSeconds),

--- a/Robot/src/main/java/com/swrobotics/robot/control/ControlBoard.java
+++ b/Robot/src/main/java/com/swrobotics/robot/control/ControlBoard.java
@@ -5,13 +5,15 @@ import com.swrobotics.lib.field.FieldInfo;
 import com.swrobotics.lib.input.XboxController;
 import com.swrobotics.lib.net.NTBoolean;
 import com.swrobotics.lib.net.NTEntry;
+import com.swrobotics.lib.net.NTInteger;
+import com.swrobotics.lib.utils.MathUtil;
 import com.swrobotics.robot.RobotContainer;
 import com.swrobotics.robot.commands.CharacterizeWheelsCommand;
 import com.swrobotics.robot.commands.LightCommands;
+import com.swrobotics.robot.commands.RumblePatternCommands;
 import com.swrobotics.robot.config.Constants;
 import com.swrobotics.robot.subsystems.swerve.SwerveDriveSubsystem;
 
-import com.swrobotics.lib.utils.MathUtil;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
@@ -21,6 +23,8 @@ import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
 
 public final class ControlBoard extends SubsystemBase {
+    private final NTInteger ENDGAME_ALERT_TIME = new NTInteger("Control/Endgame Alert Time", 15);
+
     /**
      * Driver:
      * Left stick: translation
@@ -51,6 +55,18 @@ public final class ControlBoard extends SubsystemBase {
 
         // Test LEDs
         driver.a.onRising(LightCommands.blink(robot.lights, Color.kCyan));
+
+
+        // Endgame Alert
+        /** Must restart robot code for the time change to take effect */
+        new Trigger(
+            () ->
+                DriverStation.isTeleopEnabled()
+                    && DriverStation.getMatchTime() > 0
+                    && DriverStation.getMatchTime() <= Math.round(ENDGAME_ALERT_TIME.get()))
+        .onTrue(RumblePatternCommands.endgameAlert(driver, 0.75).alongWith(RumblePatternCommands.endgameAlert(operator, 0.75)));
+
+        driver.b.onRising(RumblePatternCommands.endgameAlert(driver, 0.75));
 
         driveFilter = new DriveAccelFilter(Constants.kDriveControlMaxAccel);
 

--- a/Robot/src/main/java/com/swrobotics/robot/control/ControlBoard.java
+++ b/Robot/src/main/java/com/swrobotics/robot/control/ControlBoard.java
@@ -23,7 +23,8 @@ import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
 
 public final class ControlBoard extends SubsystemBase {
-    private final NTInteger ENDGAME_ALERT_TIME = new NTInteger("Control/Endgame Alert Time", 15);
+    private final NTInteger ENDGAME_ALERT_A_TIME = new NTInteger("Control/Endgame Alert Time A", 20);
+    private final NTInteger ENDGAME_ALERT_B_TIME = new NTInteger("Control/Endgame Alert Time B", 5);
 
     /**
      * Driver:
@@ -63,7 +64,14 @@ public final class ControlBoard extends SubsystemBase {
             () ->
                 DriverStation.isTeleopEnabled()
                     && DriverStation.getMatchTime() > 0
-                    && DriverStation.getMatchTime() <= Math.round(ENDGAME_ALERT_TIME.get()))
+                    && DriverStation.getMatchTime() <= Math.round(ENDGAME_ALERT_A_TIME.get()))
+        .onTrue(RumblePatternCommands.endgameAlert(driver, 0.75).alongWith(RumblePatternCommands.endgameAlert(operator, 0.5)));
+
+        new Trigger(
+            () ->
+                DriverStation.isTeleopEnabled()
+                    && DriverStation.getMatchTime() > 0
+                    && DriverStation.getMatchTime() <= Math.round(ENDGAME_ALERT_B_TIME.get()))
         .onTrue(RumblePatternCommands.endgameAlert(driver, 0.75).alongWith(RumblePatternCommands.endgameAlert(operator, 0.75)));
 
         driver.b.onRising(RumblePatternCommands.endgameAlert(driver, 0.75));

--- a/Robot/src/main/java/com/swrobotics/robot/control/ControlBoard.java
+++ b/Robot/src/main/java/com/swrobotics/robot/control/ControlBoard.java
@@ -23,8 +23,7 @@ import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
 
 public final class ControlBoard extends SubsystemBase {
-    private final NTInteger ENDGAME_ALERT_A_TIME = new NTInteger("Control/Endgame Alert Time A", 20);
-    private final NTInteger ENDGAME_ALERT_B_TIME = new NTInteger("Control/Endgame Alert Time B", 5);
+    private final NTInteger ENDGAME_ALERT_TIME = new NTInteger("Control/Endgame Alert Time", 15);
 
     /**
      * Driver:
@@ -64,14 +63,7 @@ public final class ControlBoard extends SubsystemBase {
             () ->
                 DriverStation.isTeleopEnabled()
                     && DriverStation.getMatchTime() > 0
-                    && DriverStation.getMatchTime() <= Math.round(ENDGAME_ALERT_A_TIME.get()))
-        .onTrue(RumblePatternCommands.endgameAlert(driver, 0.75).alongWith(RumblePatternCommands.endgameAlert(operator, 0.5)));
-
-        new Trigger(
-            () ->
-                DriverStation.isTeleopEnabled()
-                    && DriverStation.getMatchTime() > 0
-                    && DriverStation.getMatchTime() <= Math.round(ENDGAME_ALERT_B_TIME.get()))
+                    && DriverStation.getMatchTime() <= Math.round(ENDGAME_ALERT_TIME.get()))
         .onTrue(RumblePatternCommands.endgameAlert(driver, 0.75).alongWith(RumblePatternCommands.endgameAlert(operator, 0.75)));
 
         driver.b.onRising(RumblePatternCommands.endgameAlert(driver, 0.75));


### PR DESCRIPTION
Adds a unique rumble pattern when the set endgame timer is up. For example, we could say we want to climb at 15 and the controllers will buzz in a jazzy pattern then.

Working in the simulator but only in real DS mode (because the sim can't do rumble). Still needs cleanup and maybe a second timer.